### PR TITLE
dwyl/chat gitter button sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ we're *excited* that there is more *choie* in the JS testing space!
 ```md
 [![Join the chat at https://gitter.im/{ORG-or-USERNAME}/{REPO-NAME}](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ```
+#### dwyl/chat button:
+
+```md
+[![Join the chat at https://gitter.im/dwyl/chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/chat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+```
 
 ### Hit Counter [![HitCount](https://hitt.herokuapp.com/dwyl/repo-badges.svg)](https://github.com/dwyl/repo-badges)
 


### PR DESCRIPTION
adds gitter.im/dwyl/chat button we can copy-paste into other readmes
(*I often need this...*)
