### PR TITLE
Fix typo to match PR #70 from learn-security

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Select whatever is relevant to you and continue:
 
 ![06-snyk-wants-private-repos-by-default](https://user-images.githubusercontent.com/194400/49246113-0d04bf80-f40c-11e8-9766-2c3cf6f4938a.png)
 
-7. I selected _only_ **`public`** repositories as I _always_ follow the ["principal of least privilege"](https://github.com/dwyl/learn-security#principal-of-least-privilege):
+7. I selected _only_ **`public`** repositories as I _always_ follow the ["principle of least privilege"](https://github.com/dwyl/learn-security#principle-of-least-privilege):
 
 ![07-snyk-select-public-repos-only](https://user-images.githubusercontent.com/194400/49246115-0d04bf80-f40c-11e8-9a8a-ca322d79cea1.png)
 


### PR DESCRIPTION
Changed occurrence of "principal" to "principle" for compatibility with pull request #70 of your learn-security repository. <https://github.com/dwyl/learn-security/pull/70>